### PR TITLE
added support for --geometry parameter

### DIFF
--- a/src/calibrator.cpp
+++ b/src/calibrator.cpp
@@ -30,8 +30,8 @@
 #include "calibrator.hh"
 
 Calibrator::Calibrator(const char* const device_name0, const XYinfo& axys0,
-    const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type0)
-  : device_name(device_name0), old_axys(axys0), verbose(verbose0), num_clicks(0), threshold_doubleclick(thr_doubleclick), threshold_misclick(thr_misclick), output_type(output_type0)
+    const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type0, const char* geometry0)
+  : device_name(device_name0), old_axys(axys0), verbose(verbose0), num_clicks(0), threshold_doubleclick(thr_doubleclick), threshold_misclick(thr_misclick), output_type(output_type0), geometry(geometry0)
 {
 }
 
@@ -48,6 +48,11 @@ void Calibrator::set_threshold_misclick(int t)
 int Calibrator::get_numclicks()
 {
     return num_clicks;
+}
+
+const char* Calibrator::get_geometry()
+{
+    return geometry;
 }
 
 bool Calibrator::add_click(int x, int y)

--- a/src/calibrator.hh
+++ b/src/calibrator.hh
@@ -34,7 +34,7 @@ public:
      * if the touchscreen is not of the type it supports
      */
     Calibrator(const char* const device_name, const XYinfo& axys,
-        const bool verbose, const int thr_misclick=0, const int thr_doubleclick=0, const OutputType output_type=OUTYPE_AUTO);
+        const bool verbose, const int thr_misclick=0, const int thr_doubleclick=0, const OutputType output_type=OUTYPE_AUTO, const char* geometry=0);
     ~Calibrator() {}
 
     // set the doubleclick treshold
@@ -43,6 +43,8 @@ public:
     void set_threshold_misclick(int t);
     // get the number of clicks already registered
     int get_numclicks();
+    // return geometry string or NULL
+    const char* get_geometry(); 
     // reset clicks
     void reset() {
         num_clicks = 0;
@@ -84,6 +86,9 @@ protected:
 
     // Type of output
     OutputType output_type;
+
+		// manually specified geometry string
+		const char* geometry;
 
     // Check whether the given name is a sysfs device name
     bool is_sysfs_name(const char* name);

--- a/src/calibrator/calibratorEvdev.cpp
+++ b/src/calibrator/calibratorEvdev.cpp
@@ -49,7 +49,7 @@ private:
 public:
     CalibratorEvdev(const char* const device_name, const XYinfo& axys, const bool verbose,
         XID device_id=(XID)-1, const int thr_misclick=0, const int thr_doubleclick=0,
-        const OutputType output_type=OUTYPE_AUTO);
+        const OutputType output_type=OUTYPE_AUTO, const char* geometry=0);
     ~CalibratorEvdev();
 
     virtual bool finish_data(const XYinfo new_axys, int swap_xy);
@@ -67,8 +67,8 @@ protected:
     bool output_xinput(const XYinfo new_axys, int swap_xy, int new_swap_xy);
 };
 
-CalibratorEvdev::CalibratorEvdev(const char* const device_name0, const XYinfo& axys0, const bool verbose0, XID device_id, const int thr_misclick, const int thr_doubleclick, const OutputType output_type)
-  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type), old_swap_xy(0)
+CalibratorEvdev::CalibratorEvdev(const char* const device_name0, const XYinfo& axys0, const bool verbose0, XID device_id, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry)
+  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type, geometry), old_swap_xy(0)
 {
     // init
     display = XOpenDisplay(NULL);

--- a/src/calibrator/calibratorUsbtouchscreen.cpp
+++ b/src/calibrator/calibratorUsbtouchscreen.cpp
@@ -53,7 +53,7 @@ class CalibratorUsbtouchscreen: public Calibrator
 public:
     CalibratorUsbtouchscreen(const char* const device_name, const XYinfo& axys,
         const bool verbose, const int thr_misclick=0, const int thr_doubleclick=0,
-        const OutputType output_type=OUTYPE_AUTO);
+        const OutputType output_type=OUTYPE_AUTO, const char* geometry=0);
     ~CalibratorUsbtouchscreen();
 
     virtual bool finish_data(const XYinfo new_axys, int swap_xy);
@@ -134,8 +134,8 @@ protected:
     }
 };
 
-CalibratorUsbtouchscreen::CalibratorUsbtouchscreen(const char* const device_name0, const XYinfo& axys0, const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type)
-  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type)
+CalibratorUsbtouchscreen::CalibratorUsbtouchscreen(const char* const device_name0, const XYinfo& axys0, const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry)
+  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type, geometry)
 {
     if (strcmp(device_name, "Usbtouchscreen") != 0)
         throw WrongCalibratorException("Not a usbtouchscreen device");

--- a/src/calibrator/calibratorXorgPrint.cpp
+++ b/src/calibrator/calibratorXorgPrint.cpp
@@ -29,7 +29,7 @@ class CalibratorXorgPrint: public Calibrator
 public:
     CalibratorXorgPrint(const char* const device_name, const XYinfo& axys,
         const bool verbose, const int thr_misclick=0, const int thr_doubleclick=0,
-        const OutputType output_type=OUTYPE_AUTO);
+        const OutputType output_type=OUTYPE_AUTO, const char* geometry=0);
 
     virtual bool finish_data(const XYinfo new_axys, int swap_xy);
 protected:
@@ -37,8 +37,8 @@ protected:
     bool output_hal(const XYinfo new_axys, int swap_xy, int new_swap_xy);
 };
 
-CalibratorXorgPrint::CalibratorXorgPrint(const char* const device_name0, const XYinfo& axys0, const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type)
-  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type)
+CalibratorXorgPrint::CalibratorXorgPrint(const char* const device_name0, const XYinfo& axys0, const bool verbose0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry)
+  : Calibrator(device_name0, axys0, verbose0, thr_misclick, thr_doubleclick, output_type, geometry)
 {
     printf("Calibrating standard Xorg driver \"%s\"\n", device_name);
     printf("\tcurrent calibration values: min_x=%d, max_x=%d and min_y=%d, max_y=%d\n",

--- a/src/gui/gui_x11.cpp
+++ b/src/gui/gui_x11.cpp
@@ -144,13 +144,30 @@ GuiCalibratorX11::GuiCalibratorX11(Calibrator* calibrator0)
                      DisplayHeight(display, screen_num));
 #endif
 
+    // window offsets
+    int gx = 0;
+    int gy = 0;
+
+    // parse geometry string
+    const char* geo = calibrator->get_geometry();
+    if (geo != NULL) {
+      int gw,gh;
+      int res = sscanf(geo,"%dx%d+%d+%d",&gw,&gh,&gx,&gy);
+      if (res != 4) {
+        fprintf(stderr,"Warning: error parsing geometry string - using defaults.\n");
+        gx = gy = 0;
+      } else {
+        set_display_size( gw, gh );
+      }
+    }
+
     // Register events on the window
     XSetWindowAttributes attributes;
     attributes.override_redirect = True;
     attributes.event_mask = ExposureMask | KeyPressMask | ButtonPressMask;
 
     win = XCreateWindow(display, RootWindow(display, screen_num),
-                0, 424, display_width, display_height, 0,
+                gx, gy, display_width, display_height, 0,
                 CopyFromParent, InputOutput, CopyFromParent,
                 CWOverrideRedirect | CWEventMask,
                 &attributes);
@@ -216,6 +233,7 @@ void GuiCalibratorX11::redraw()
     XRRScreenSize* randrsize = XRRSizes(display, screen_num, &nsizes);
     if (nsizes != 0 && (display_width != randrsize->width ||
                         display_height != randrsize->height)) {
+      if (calibrator->get_geometry() == NULL)
         set_display_size(randrsize->width, randrsize->height);
     }
 #endif


### PR DESCRIPTION
Hello Tias,

my T410s laptop has a touchscreen + Nvidia card. When configured as Twinview with an external monitor, the screen size detection doesn't work properly, so I've added support for a --geometry commandline parameter to explicitly specify the size & position of the calibration window. Would be great if you can merge this into your mainline.

Florian
