### PR TITLE
no window manager patch for gtkmm

### DIFF
--- a/src/main_gtkmm.cpp
+++ b/src/main_gtkmm.cpp
@@ -37,8 +37,14 @@ int main(int argc, char** argv)
     // GTK-mm setup
     Gtk::Main kit(argc, argv);
 
+    Glib::RefPtr< Gdk::Screen > screen = Gdk::Screen::get_default();
+    int num_monitors = screen->get_n_monitors();
+    Gdk::Rectangle rect;
+    screen->get_monitor_geometry(0, rect);
+
     Gtk::Window win;
-    win.fullscreen();
+    win.move(rect.get_x(), rect.get_y());
+    win.resize(rect.get_width(), rect.get_height());
 
     CalibrationArea area(calibrator);
     win.add(area);


### PR DESCRIPTION
Related to Gtkmm::Window::fullscreen() method some window manager unable to run this command. On my system with no window manager (we do it by hands from Java) xinput_calibrator unable to create main window on fullscreen (it appear as small window in up left corner).

You can easy reproduce this behavior by running from console (xinit /usr/bin/xterm) and in xterm run xinput_calibrator. You will see this problem.

Here documentation link:
http://library.gnome.org/devel/gtkmm/unstable/classGtk_1_1Window.html#a2343d2ece18fc8cf4db9e9de4764f386

As you can see from the code here a one unused variable (num_monitors). Because on systems with dual heads you need to create two Gtk::Window objects for booth of monitors and choise right touchscreen to each one... I don't know how to solve it yet, but later we can figure this out by some application arguments.
