### PR TITLE
Add include for pause()

### DIFF
--- a/src/main_x11.cpp
+++ b/src/main_x11.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include <unistd.h>
 #include "calibrator.hh"
 #include "gui/x11.hpp"
 


### PR DESCRIPTION
On debian Linux unstable, main_x11.cpp is missing an include:

```
main_x11.cpp: In function ‘int main(int, char**)’:
main_x11.cpp:34:15: error: ‘pause’ was not declared in this scope
```
