### PR TITLE
Use timerfd if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,22 @@ AS_IF([test "x$with_gui" = xdefault || test "x$with_gui" = xx11], [
 ])
 AM_CONDITIONAL([BUILD_X11], [test "x$with_gui" = xx11])
 
+AC_CACHE_CHECK(for timerfd_create(2) system call,
+    glib_cv_timerfd,AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <sys/timerfd.h>
+#include <unistd.h>
+],[
+int
+main (void)
+{
+  timerfd_create (CLOCK_MONOTONIC, TFD_CLOEXEC);
+  return 0;
+}
+])],glib_cv_timerfd=yes,glib_cv_timerfd=no))
+if test x"$glib_cv_timerfd" = x"yes"; then
+  AC_DEFINE(HAVE_TIMERFD, 1, [we have the timerfd_create(2) system call])
+fi
+AM_CONDITIONAL(HAVE_TIMERFD, [test "$glib_cv_timerfd" = "yes"])
 
 
 AC_SUBST(VERSION)

--- a/src/gui/x11.hpp
+++ b/src/gui/x11.hpp
@@ -51,6 +51,10 @@ protected:
     GC gc;
     XFontStruct* font_info;
 
+#ifdef HAVE_TIMERFD
+    int timer_fd;
+#endif
+
     // color management
     enum { BLACK=0, WHITE=1, GRAY=2, DIMGRAY=3, RED=4, NUM_COLORS };
     static const char* colors[NUM_COLORS];

--- a/src/main_x11.cpp
+++ b/src/main_x11.cpp
@@ -30,9 +30,14 @@ int main(int argc, char** argv)
 
     GuiCalibratorX11::make_instance( calibrator );
 
+#ifdef HAVE_TIMERFD
+    while (1)
+    	GuiCalibratorX11::give_timer_signal();
+#else
     // wait for timer signal, processes events
     while(1)
         pause();
+#endif
 
     delete calibrator;
     return 0;


### PR DESCRIPTION
The timerfd interface is a Linux-specific set of functions that present
POSIX timers as file descriptors (hence the fd) rather than signals thus
avoiding all that tedious messing about with signal handlers.
It was first implemented in GNU libc 2.8 and kernel 2.6.25.

Signed-off-by: Christian Gmeiner christian.gmeiner@gmail.com
