### PR TITLE
Correct screen size detection

### DIFF
--- a/src/gui/x11.hpp
+++ b/src/gui/x11.hpp
@@ -68,6 +68,7 @@ protected:
     bool on_button_press_event(XEvent event);
 
     // Helper functions
+    void detect_display_size(int &width, int &height);
     void set_display_size(int width, int height);
     void redraw();
     void draw_message(const char* msg);


### PR DESCRIPTION
The XRandR api was used in a such way to get the _DEFAULT_ size instead the
current one. This patch create a helper function (detect_display_size()) which
detects the current size of the screen; it  is called both in the
GuiCalibratorX11() constructor and in the redraw() method.

How reproduce the problem:
1) compile xinput for X11 ( autogen.sh --with-gui=x11)
2) change the resolution to a not default one (like xrandr -s 640x480)
3) start xinput_calibrator
4) the result is a window size equal to the size of the _DEFAULT_ resolution of the screen, and not the current one
5) expected result: a window size equal to the size of the _CURRENT_ resolution of the screen 
