### PR TITLE
CalibratorEvdev::output_xinput: unset axis inversion in generate script

### DIFF
--- a/src/calibrator/Evdev.cpp
+++ b/src/calibrator/Evdev.cpp
@@ -615,6 +615,13 @@ bool CalibratorEvdev::output_xinput(const XYinfo new_axys)
     sprintf(line, "    xinput set-int-prop \"%s\" \"Evdev Axes Swap\" 8 %d\n", device_name, new_axys.swap_xy);
     outstr += line;
 
+    /*
+     * Since we alway clear out the inversion flags, make sure the generated
+     * script does so as well.
+     */
+    sprintf(line, "    xinput set-int-prop \"%s\" \"Evdev Axis Inversion\" 8 0 0\n", device_name);
+    outstr += line;
+
     // console out
     printf("%s", outstr.c_str());
     // file out


### PR DESCRIPTION
Since the calibrator implicitely includes axis inversion in the calibration
values, resetting the evdev inversion properties, the generated xinput script
must also ensure that the inversion properties are cleared.