### PR TITLE
Add option --valuator option to xinput_calibrator

### DIFF
--- a/src/calibrator/Evdev.hpp
+++ b/src/calibrator/Evdev.hpp
@@ -47,6 +47,7 @@ protected:
                     const int thr_doubleclick=0,
                     const OutputType output_type=OUTYPE_AUTO,
                     const char* geometry=0,
+                    const bool use_valuator=false,
                     const bool use_timeout=false,
                     const char* output_filename = 0);
 
@@ -58,6 +59,7 @@ public:
                     const int thr_doubleclick=0,
                     const OutputType output_type=OUTYPE_AUTO,
                     const char* geometry=0,
+                    const bool use_valuator=false,
                     const bool use_timeout=false,
                     const char* output_filename = 0);
     virtual ~CalibratorEvdev();


### PR DESCRIPTION
Add option --valuator option to xinput_calibrator that uses
the valuator range without pre-calibration values and without
coordinate inversion.
