### PR TITLE
Add option for setting timeout value

### DIFF
--- a/man/xinput_calibrator.1
+++ b/man/xinput_calibrator.1
@@ -51,8 +51,12 @@ This is useful if the calibration values are stored in your xorg.conf, but the d
 set the misclick threshold (0=off, default: 15 pixels)
 .PP 
 .TP 8
-.B \-\-no-timeout
-turns off the timeout
+.B \-\-no\-timeout
+turns off the timeout; same as --timeout 0
+.PP 
+.TP 8
+.B \-\-timeout \fIsec\fP
+sets the timeout, in seconds (0=no timeout, default: 15 sec)
 .PP 
 .TP 8
 .B \-\-output\-type \fIauto|xorg.conf.d|hal|xinput\fP

--- a/src/calibrator.cpp
+++ b/src/calibrator.cpp
@@ -40,10 +40,10 @@ const char* Calibrator::SYSFS_DEVNAME="device/name";
 Calibrator::Calibrator(const char* const device_name0, const XYinfo& axys0,
     const int thr_misclick, const int thr_doubleclick,
     const OutputType output_type0, const char* geometry0,
-    const bool use_timeout0, const char* output_filename0)
+    const int timeout0, const char* output_filename0)
 : device_name(device_name0),
     threshold_doubleclick(thr_doubleclick), threshold_misclick(thr_misclick),
-    output_type(output_type0), geometry(geometry0), use_timeout(use_timeout0),
+    output_type(output_type0), geometry(geometry0), timeout(timeout0),
     output_filename(output_filename0)
 {
     old_axys = axys0;

--- a/src/calibrator.hh
+++ b/src/calibrator.hh
@@ -148,7 +148,7 @@ public:
                const int thr_doubleclick=0,
                const OutputType output_type=OUTYPE_AUTO,
                const char* geometry=0,
-               const bool use_timeout=1,
+               const int timeout=0,
                const char* output_filename = 0);
 
     virtual ~Calibrator() {}
@@ -181,8 +181,8 @@ public:
     /// returns NULL if it can not be found
     const char* get_sysfs_name();
 
-    const bool get_use_timeout() const
-    { return use_timeout; }
+    const int get_timeout() const
+    { return timeout; }
 
     /// get output filename set at cmdline or NULL
     const char* get_output_filename() const
@@ -237,7 +237,7 @@ protected:
     // manually specified geometry string
     const char* geometry;
 
-    const bool use_timeout;
+    const int timeout;
 
     // manually specified output filename
     const char* output_filename;

--- a/src/calibrator/Evdev.cpp
+++ b/src/calibrator/Evdev.cpp
@@ -47,9 +47,9 @@ CalibratorEvdev::CalibratorEvdev(const char* const device_name0,
                                  const int thr_doubleclick,
                                  const OutputType output_type,
                                  const char* geometry,
-                                 const bool use_timeout,
+                                 const int timeout,
                                  const char* output_filename)
-  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, use_timeout, output_filename)
+  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, timeout, output_filename)
 {
     // init
     display = XOpenDisplay(NULL);
@@ -167,9 +167,9 @@ CalibratorEvdev::CalibratorEvdev(const char* const device_name0,
                                  const int thr_doubleclick,
                                  const OutputType output_type,
                                  const char* geometry,
-                                 const bool use_timeout,
+                                 const int timeout,
                                  const char* output_filename)
-  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, output_filename) { }
+  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, timeout, output_filename) { }
 
 // Destructor
 CalibratorEvdev::~CalibratorEvdev () {

--- a/src/calibrator/Evdev.hpp
+++ b/src/calibrator/Evdev.hpp
@@ -47,7 +47,7 @@ protected:
                     const int thr_doubleclick=0,
                     const OutputType output_type=OUTYPE_AUTO,
                     const char* geometry=0,
-                    const bool use_timeout=false,
+                    const int timeout=0,
                     const char* output_filename = 0);
 
 public:
@@ -58,7 +58,7 @@ public:
                     const int thr_doubleclick=0,
                     const OutputType output_type=OUTYPE_AUTO,
                     const char* geometry=0,
-                    const bool use_timeout=false,
+                    const int timeout=0,
                     const char* output_filename = 0);
     virtual ~CalibratorEvdev();
 

--- a/src/calibrator/Usbtouchscreen.cpp
+++ b/src/calibrator/Usbtouchscreen.cpp
@@ -48,8 +48,8 @@ static const char *p_flip_x = "flip_x";
 static const char *p_flip_y = "flip_y";
 static const char *p_swap_xy = "swap_xy";
 
-CalibratorUsbtouchscreen::CalibratorUsbtouchscreen(const char* const device_name0, const XYinfo& axys0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry, const bool use_timeout, const char* output_filename)
-  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, use_timeout, output_filename)
+CalibratorUsbtouchscreen::CalibratorUsbtouchscreen(const char* const device_name0, const XYinfo& axys0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry, const int timeout, const char* output_filename)
+  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, timeout, output_filename)
 {
     if (strcmp(device_name, "Usbtouchscreen") != 0)
         throw WrongCalibratorException("Not a usbtouchscreen device");

--- a/src/calibrator/Usbtouchscreen.hpp
+++ b/src/calibrator/Usbtouchscreen.hpp
@@ -35,7 +35,7 @@ public:
     CalibratorUsbtouchscreen(const char* const device_name, const XYinfo& axys,
          const int thr_misclick=0, const int thr_doubleclick=0,
         const OutputType output_type=OUTYPE_AUTO, const char* geometry=0,
-        const bool use_timeout=false, const char* output_filename = 0);
+        const int timeout=0, const char* output_filename = 0);
     virtual ~CalibratorUsbtouchscreen();
 
     virtual bool finish_data(const XYinfo &new_axys);

--- a/src/calibrator/XorgPrint.cpp
+++ b/src/calibrator/XorgPrint.cpp
@@ -24,8 +24,8 @@
 
 #include <cstdio>
 
-CalibratorXorgPrint::CalibratorXorgPrint(const char* const device_name0, const XYinfo& axys0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry, const bool use_timeout, const char* output_filename)
-  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, use_timeout, output_filename)
+CalibratorXorgPrint::CalibratorXorgPrint(const char* const device_name0, const XYinfo& axys0, const int thr_misclick, const int thr_doubleclick, const OutputType output_type, const char* geometry, const int timeout, const char* output_filename)
+  : Calibrator(device_name0, axys0, thr_misclick, thr_doubleclick, output_type, geometry, timeout, output_filename)
 {
     printf("Calibrating standard Xorg driver \"%s\"\n", device_name);
     printf("\tcurrent calibration values: min_x=%d, max_x=%d and min_y=%d, max_y=%d\n",

--- a/src/calibrator/XorgPrint.hpp
+++ b/src/calibrator/XorgPrint.hpp
@@ -35,7 +35,7 @@ public:
     CalibratorXorgPrint(const char* const device_name, const XYinfo& axys,
         const int thr_misclick=0, const int thr_doubleclick=0,
         const OutputType output_type=OUTYPE_AUTO, const char* geometry=0,
-        const bool use_timeout=false, const char* output_filename = 0);
+        const int timeout=0, const char* output_filename = 0);
 
     virtual bool finish_data(const XYinfo &new_axys);
 

--- a/src/gui/gtkmm.cpp
+++ b/src/gui/gtkmm.cpp
@@ -49,7 +49,7 @@ CalibrationArea::CalibrationArea(Calibrator* calibrator0)
         set_display_size(get_width(), get_height());
 
     // Setup timer for animation
-    if(calibrator->get_use_timeout()){
+    if(calibrator->get_timeout() > 0){
         sigc::slot<bool> slot = sigc::mem_fun(*this, &CalibrationArea::on_timer_signal);
         Glib::signal_timeout().connect(slot, time_step);
     }
@@ -136,7 +136,11 @@ bool CalibrationArea::on_expose_event(GdkEventExpose *event)
             cr->arc(X[i], Y[i], cross_circle, 0.0, 2.0 * M_PI);
             cr->stroke();
         }
-        if(calibrator->get_use_timeout()){
+
+	int max_time = 15000;
+	
+        if(calibrator->get_timeout() > 0) {
+            max_time = calibrator->get_timeout();
             // Draw the clock background
             cr->arc(display_width/2, display_height/2, clock_radius/2, 0.0, 2.0 * M_PI);
             cr->set_source_rgb(0.5, 0.5, 0.5);
@@ -189,7 +193,8 @@ void CalibrationArea::redraw()
 
 bool CalibrationArea::on_timer_signal()
 {
-    if (calibrator->get_use_timeout()) {
+    if (calibrator->get_timeout() > 0) {
+        int max_time = calibrator->get_timeout();
         time_elapsed += time_step;
         if (time_elapsed > max_time) {
             exit(0);

--- a/src/gui/gui_common.cpp
+++ b/src/gui/gui_common.cpp
@@ -43,7 +43,7 @@ void get_display_texts(std::list<std::string> *texts, Calibrator *calibrator)
 	texts->push_back(str);
     /* 4th line */
     str = "(To abort, press any key";
-    if(calibrator->get_use_timeout())
+    if(calibrator->get_timeout()>0)
         str += " or wait)";
     else
         str += ")";

--- a/src/gui/gui_common.hpp
+++ b/src/gui/gui_common.hpp
@@ -29,7 +29,6 @@
 
 // Timeout parameters
 const int time_step = 100;  // in milliseconds
-const int max_time = 15000; // in milliseconds, 5000 = 5 sec
 
 // Clock appereance
 const int cross_lines = 25;

--- a/src/gui/x11.cpp
+++ b/src/gui/x11.cpp
@@ -268,7 +268,7 @@ void GuiCalibratorX11::redraw()
     }
 
     // Draw the clock background
-    if(calibrator->get_use_timeout()){
+    if(calibrator->get_timeout() > 0) {
         XSetForeground(display, gc, pixel[DIMGRAY]);
         XSetLineAttributes(display, gc, 0, LineSolid, CapRound, JoinRound);
         XFillArc(display, win, gc, (display_width-clock_radius)/2, (display_height - clock_radius)/2,
@@ -284,8 +284,9 @@ void GuiCalibratorX11::on_expose_event()
 void GuiCalibratorX11::on_timer_signal()
 {
     // Update clock
-    if(calibrator->get_use_timeout()) {
-
+    if(calibrator->get_timeout() > 0) {
+        int max_time = calibrator->get_timeout();
+	
         time_elapsed += time_step;
         if (time_elapsed > max_time) {
             exit(0);


### PR DESCRIPTION
This commit adds a '--timeout <N>' option by which users can specify the
amount of seconds for the timeout, or 0 to disable it.

This is useful in those cases in which the default value (15 seconds) is
too short or even too long.

Actually the existing '--no-timeout' has been kept for compatibility and
is a shortcut for '--timeout 0'.